### PR TITLE
Update documentation, make code more user-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The available features to extract are stored as the static methods of `detproces
  - `of_constrained`: returns the constrained optimum filter amplitude, time offset, and chi-square, where a window constraint is specified
  - `baseline`: returns the average value from the beginning of an event up to some specified index
  - `integral`: returns the integral of the event **(no baseline subtraction)** from some specified start index to some specified end index
- - `maximum`: returns the maximum value of the event
- - `minimum`: returns the minimum value of the event
+ - `maximum`: returns the maximum value of the event from some specified start index to some specified end index
+ - `minimum`: returns the minimum value of the event from some specified start index to some specified end index
  - `energyabsorbed`: returns the energy absorbed by a Transition-Edge Sensor (TES) based on the inputted parameters that correspond to the TES bias point
 
 More features can be added either locally, or if there is a feature that is universally useful, then please submit a Pull Request! See [Advanced Usage](#advanced-usage) for instructions on adding features.
@@ -105,7 +105,145 @@ Beyond the basic functionality of `detprocess`, advanced users may want to do mo
 
 ### Adding New Features
 
-For advanced users, there may be a need to add new features for extraction which are not currently included. To do this, the user must add a new feature as a `staticmethod` in `detprocess.SingleChannelExtractors`.
+For advanced users, there may be a need to add new features for extraction which are not currently included. To do this, the user must add a new feature as a `staticmethod` in `detprocess.SingleChannelExtractors`. To understand how to do this, let's look at a couple of the currently-supported features. Below we show an excerpt of the feature definitions, showing how `of_nodelay` and `integral` are defined in `detprocess/process/_features.py`.
+
+```python
+class SingleChannelExtractors(object):
+    """
+    A class that contains all of the possible feature extractors
+    for a given trace, assuming processing on a single channel.
+    Each feature extraction function is a staticmethod for processing
+    convenience.
+
+    """
+
+    @staticmethod
+    def of_nodelay(trace, template, psd, fs, **kwargs):
+        """
+        Feature extraction for the no delay Optimum Filter.
+
+        Parameters
+        ----------
+        trace : ndarray
+            An ndarray containing the raw data to extract the feature from.
+        template : ndarray
+            The template to use for the optimum filter.
+        psd : ndarray
+            The PSD to use for the optimum filter.
+        fs : float
+            The digitization rate of the data in trace.
+
+        Returns
+        -------
+        retdict : dict
+            Dictionary containing the various extracted features.
+
+        """
+
+        OF = qp.OptimumFilter(
+            trace,
+            template,
+            psd,
+            fs,
+        )
+        ofamp_nodelay, ofchi2_nodelay = OF.ofamp_nodelay()
+
+        retdict = {
+            'ofamp_nodelay': ofamp_nodelay,
+            'ofchi2_nodelay': ofchi2_nodelay,
+        }
+        return retdict
+
+## features between these have been truncated from the source code
+
+    @staticmethod
+    def integral(trace, start_index, end_index, fs, **kwargs):
+        """
+        Feature extraction for the pulse integral.
+
+        Parameters
+        ----------
+        trace : ndarray
+            An ndarray containing the raw data to extract the feature from.
+        start_index : int
+            The index of the trace to start the integration.
+        end_index : int
+            The index of the trace to end the integration.
+        fs : float
+            The digitization rate of the data in trace.
+
+        Returns
+        -------
+        retdict : dict
+            Dictionary containing the various extracted features.
+
+        """
+
+        integral = np.trapz(trace[start_index:end_index]) / fs
+
+        retdict = {
+            'integral': integral,
+        }
+
+        return retdict
+
+```
+
+We should note that, when comparing to our example [YAML file](#yaml-file), there are three special arguments that are being passed to the features, which we did not directly define in that file: `template`, `psd`, and `fs`. The reason is that `template` and `psd` are defined from opening the text files `template_path` and `psd_path`, while `fs` is contained in the `pytesdaq` file being processed, so it does not need to be defined by the user. These special arguments can always be included in a new feature by directly specifying them, otherwise they are ignored. To support these special features, each extraction function **must** have `**kwargs` in its definition.
+
+For the `integral` feature, we see that there are two arguments which are defined in our example [YAML file](#yaml-file): `start_index` and `end_index`. As these are arguments that are needed specifically for this feature, they must be defined in the YAML file.
+
+Each feature function can return multiple values, if needed, as shown by `of_nodelay`. The `detprocess` processing routine will use the defined keys in the returned dictionary `retdict` to save them to the outputted Pandas DataFrame. Note that, to ensure unique names if we are processing multiple channels in the same file, `detprocess` will append the channel name to the saved feature. That is, the outputted DataFrame for our example [YAML file](#yaml-file) for these two specified feature function would have the following keys saved: `ofamp_nodelay_detector1`, `ofchi2_nodelay_detector1`, and `integral_detector1`.
+
+To create a new feature, we would follow the format of the above features. Let's create a feature called `example_feature`, defined below, where `some_function` takes the place of the code that would be used to extract the features. Let's say this feature needs the parameters `param1` and `param2`, as well as the special argument `fs`. We include the required `**kwargs` for support of the special features.
+
+```python
+    @staticmethod
+    def example_feature(trace, param1, param2, fs, **kwargs):
+        """
+        Feature extraction for the pulse integral.
+
+        Parameters
+        ----------
+        trace : ndarray
+            An ndarray containing the raw data to extract the feature from.
+        param1 : float
+            The first parameter to pass to our feature extraction.
+        param2 : float
+            The first parameter to pass to our feature extraction.
+        fs : float
+            The digitization rate of the data in trace.
+
+        Returns
+        -------
+        retdict : dict
+            Dictionary containing the various extracted features.
+
+        """
+
+        output1, output2 = some_function(trace, param1, param2, fs)
+
+        retdict = {
+            'example_feature1': output1,
+            'example_feature2': output2,
+        }
+
+        return retdict
+
+```
+
+This feature must be added as one of the static methods in the class `SingleChannelExtractors`, located in `detprocess/process/_features.py`. After adding the code, the user must then recompile the package via `pip install .`, and the feature can be extracted by `detprocess`.
+
+If we added this feature to our example [YAML file](#yaml-file), the corresponding entry should be of the form:
+
+```yaml
+    example_feature:
+        run: True
+        param1: 0
+        param2: 1
+```
+
+When running `detprocess.process_data`, the outputted Pandas DataFrame would then have the keys `example_feature1_detector1` and `example_feature2_detector1`, which can then be accessed by the user in their analysis.
 
 ### High-Performance Computing
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ detector1:
         end_index: 16000
 ```
 
-In this YAML file, we have supplied absolute paths to both the pulse template and the current-referenced power spectral density (PSD) to be used by the optimum filters. The pulse template should be a single array that contains the expected pulse shape, normalized to have a pulse amplitude of 1 and have a baseline of 0. The current-referenced PSD should be a single array that contains the two-sided in units of <img src="https://render.githubusercontent.com/render/math?math=%5Cmathrm%7BA%7D%5E2%20%2F%20%5Cmathrm%7BHz%7D">. Note that both of these will should have the same digitization rate and length as the data that will be processed to be able to calculate the optimum filter features.
+
+
+In this YAML file, we first specify which channel will be processed, in this case `detector1`. This should match the channel name in the corresponding `pytesdaq` file. We have supplied absolute paths to both the pulse template and the current-referenced power spectral density (PSD) to be used by the optimum filters. The pulse template should be a single array that contains the expected pulse shape, normalized to have a pulse amplitude of 1 and have a baseline of 0. The current-referenced PSD should be a single array that contains the two-sided PSD in units of <img src="https://render.githubusercontent.com/render/math?math=%5Cmathrm%7BA%7D%5E2%20%2F%20%5Cmathrm%7BHz%7D">. Note that both of these will should have the same digitization rate and/or length as the data that will be processed to be able to calculate the optimum filter features.
 
 We have also specified to extract 3 different features from each event: `of_nodelay`, `baseline`, and `integral`. This is done by specifying `run: True` in the file, as compared to `run: False` for `of_unconstrained` and `of_constrained`. Note that it is fine to simple exclude features from the YAML file, as they simply will not be calculated (e.g. `energyabsorbed` is not included in this example).
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,50 @@ To install the most recent development version of RQpy, clone this repo, then fr
 `pip install .`
 
 If using a shared Python installation, you may want to add the `--user` flag to the above line. Note the package requirements, especially the need for [QETpy](https://github.com/ucbpylegroup/QETpy) and [`pytesdaq`](https://github.com/berkeleytes/pytesdaq).
+
+## Usage
+
+One of the goals of this package is to keep the feature extraction pipeline simple and modular. The pipeline in mind can be approximated as follows:
+1. Know what features you want to extract, see: [Available Features](#available-features)
+2. Create a YAML file specifying feature extraction options, see: [YAML File](#yaml-file)
+3. Run the feature extraction code on your data
+4. Analyze the features that you have extracted
+
+
+### Available Features
+
+The available features to extract are stored as the static methods of `detprocess.SingleChannelExtractors`. Each of these methods take your data and extract that specific feature from each event. At this time, the available features are:
+ - `of_nodelay`
+ - `of_unconstrained`
+ - `of_constrained`
+ - `baseline`
+ - `integral`
+ - `maximum`
+ - `minimum`
+ - `energyabsorbed`
+
+
+### YAML File
+
+The YAML file contains nearly all of the information needed to extract features from your data. This is done on purpose, as it allows the user to easily reuse/change their YAML files for different processing, to easily version control their processing, and easily share their processing setup with collaborators. To make sure we can do this, the YAML must  have a specific format. Here's an example below.
+
+```yaml
+detector1:
+    template_path: /path/to/template.txt
+    psd_path: /path/to/psd.txt
+    of_nodelay:
+        run: True
+    of_unconstrained:
+        run: False
+    of_constrained:
+        run: False
+        windowcenter: 0
+        nconstrain: 100
+    baseline:
+        run: True
+        end_index: 16000
+    integral:
+        run: True
+        start_index: 0
+        end_index: 16000
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
   - [Available Features](#available-features)
   - [YAML File](#yaml-file)
   - [Extracting Features](#extracting-features)
+  - [Loading Features](#loading-features)
 - [Advanced Usage](#advanced-usage)
+  - [Adding New Features](#adding-new-features)
+  - [High-Performance Computing](#high-performance-computing)
 
 ## Installation
 
@@ -98,6 +101,12 @@ After feature extraction is complete (assuming that the user chose to save the p
 
 ## Advanced Usage
 
+Beyond the basic functionality of `detprocess`, advanced users may want to do more, such as adding new features or interfacing with a high-performance computing (HPC) cluster. In this section, we detail how to do these.
+
+### Adding New Features
+
 For advanced users, there may be a need to add new features for extraction which are not currently included. To do this, the user must add a new feature as a `staticmethod` in `detprocess.SingleChannelExtractors`.
 
+### High-Performance Computing
 
+Detailing this usage is a work-in-progress.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ One of the goals of this package is to keep the feature extraction pipeline simp
 1. Know what features you want to extract, see: [Available Features](#available-features)
 2. Create a YAML file specifying feature extraction options, see: [YAML File](#yaml-file)
 3. Run the feature extraction code on your data, see: [Extracting Features](#extracting-features)
-4. Analyze the features that you have extracted
+4. Analyze the features that you have extracted, see: [Loading Features](#loading-features)
 
 
 ### Available Features
@@ -82,8 +82,6 @@ detector1:
         end_index: 16000
 ```
 
-
-
 In this YAML file, we first specify which channel will be processed, in this case `detector1`. This should match the channel name in the corresponding `pytesdaq` file. We have supplied absolute paths to both the pulse template and the current-referenced power spectral density (PSD) to be used by the optimum filters. The pulse template should be a single array that contains the expected pulse shape, normalized to have a pulse amplitude of 1 and have a baseline of 0. The current-referenced PSD should be a single array that contains the two-sided PSD in units of <img src="https://render.githubusercontent.com/render/math?math=%5Cmathrm%7BA%7D%5E2%20%2F%20%5Cmathrm%7BHz%7D">. Note that both of these will should have the same digitization rate and/or length as the data that will be processed to be able to calculate the optimum filter features.
 
 We have also specified to extract 3 different features from each event: `of_nodelay`, `baseline`, and `integral`. This is done by specifying `run: True` in the file, as compared to `run: False` for `of_unconstrained` and `of_constrained`. Note that it is fine to simple exclude features from the YAML file, as they simply will not be calculated (e.g. `energyabsorbed` is not included in this example).
@@ -92,8 +90,14 @@ For the features themselves, the functions to extract them may require extra arg
 
 ### Extracting Features
 
-Feature extraction is meant to be very easy once we have our features and our YAML file. Essentially all of the work is done by `detprocess.process_data`. This function takes the absolute path to the file to be processed and the absolute path to the YAML file, and then will return a DataFrame containing all of the extracted features.
+Feature extraction is meant to be very easy once we have our features and our YAML file. Essentially all of the work is done by `detprocess.process_data`. This function takes the absolute path to the file to be processed and the absolute path to the YAML file, and then will return a DataFrame containing all of the extracted features. The user can ensure these are automatically saved to a folder of their choice by also passing a path to the `savepath` optional argument. An example of the expected workflow is shown in [`examples/run_detprocess.ipynb`](examples/run_detprocess.ipynb).
+
+### Loading Features
+
+After feature extraction is complete (assuming that the user chose to save the processed data), it is simple to load the features. As part of the IO functionality, `detprocess` has a function to load the extracted features into a Pandas DataFrame. This is done by `detprocess.io.load_features`, the example notebook [`examples/run_detprocess.ipynb`](examples/run_detprocess.ipynb) shows usage of this function.
 
 ## Advanced Usage
+
+For advanced users, there may be a need to add new features for extraction which are not currently included. To do this, the user must add a new feature as a `staticmethod` in `detprocess.SingleChannelExtractors`.
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 [![Python 3.6](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/release/python-360/)
 
-`detprocess` is a Python package meant for feature extraction from raw detector data saved by [`pytesdaq`](https://github.com/berkeleytes/pytesdaq). The main functionality of the code is contained in `detprocess/process`, which contains all the possible features to be extracted and the general pipeline of how features are extracted. This package also contains helper IO functions for loading events from `pytesdaq` and saving the processed data as Pandas DataFrames.
+`detprocess` is a Python package meant for feature extraction from raw detector data saved by [`pytesdaq`](https://github.com/berkeleytes/pytesdaq). The main functionality of the code is contained in `detprocess.process`, which contains all the possible features to be extracted and the general pipeline of how features are extracted. This package also contains helper IO functions for loading events from `pytesdaq` and saving the processed data as Pandas DataFrames.
+
+### Table of Contents
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Available Features](#available-features)
+  - [YAML File](#yaml-file)
+  - [Extracting Features](#extracting-features)
+- [Advanced Usage](#advanced-usage)
 
 ## Installation
 
@@ -17,22 +25,37 @@ If using a shared Python installation, you may want to add the `--user` flag to 
 One of the goals of this package is to keep the feature extraction pipeline simple and modular. The pipeline in mind can be approximated as follows:
 1. Know what features you want to extract, see: [Available Features](#available-features)
 2. Create a YAML file specifying feature extraction options, see: [YAML File](#yaml-file)
-3. Run the feature extraction code on your data
+3. Run the feature extraction code on your data, see: [Extracting Features](#extracting-features)
 4. Analyze the features that you have extracted
 
 
 ### Available Features
 
 The available features to extract are stored as the static methods of `detprocess.SingleChannelExtractors`. Each of these methods take your data and extract that specific feature from each event. At this time, the available features are:
- - `of_nodelay`
- - `of_unconstrained`
- - `of_constrained`
- - `baseline`
- - `integral`
- - `maximum`
- - `minimum`
- - `energyabsorbed`
 
+ - `of_nodelay`: returns the no delay optimum filter amplitude and chi-square (as in, the amplitude if the template is not allowed a time degree-of-freedom)
+ - `of_unconstrained`: returns the unconstrained optimum filter amplitude, time offset, and chi-square
+ - `of_constrained`: returns the constrained optimum filter amplitude, time offset, and chi-square, where a window constraint is specified
+ - `baseline`: returns the average value from the beginning of an event up to some specified index
+ - `integral`: returns the integral of the event **(no baseline subtraction)** from some specified start index to some specified end index
+ - `maximum`: returns the maximum value of the event
+ - `minimum`: returns the minimum value of the event
+ - `energyabsorbed`: returns the energy absorbed by a Transition-Edge Sensor (TES) based on the inputted parameters that correspond to the TES bias point
+
+More features can be added either locally, or if there is a feature that is universally useful, then please submit a Pull Request! See [Advanced Usage](#advanced-usage) for instructions on adding features.
+
+There are also features that are stored directly in `pytesdaq` files, which `detprocess` will also extract. These are:
+
+- `eventnumber`
+- `eventindex`
+- `dumpnumber`
+- `seriesnumber`
+- `eventtime`
+- `triggertype`
+- `triggeramp`
+- `triggertime`
+
+To understand these more, we direct the user to [`pytesdaq`'s Documentation](https://github.com/berkeleytes/pytesdaq).
 
 ### YAML File
 
@@ -58,3 +81,17 @@ detector1:
         start_index: 0
         end_index: 16000
 ```
+
+In this YAML file, we have supplied absolute paths to both the pulse template and the current-referenced power spectral density (PSD) to be used by the optimum filters. The pulse template should be a single array that contains the expected pulse shape, normalized to have a pulse amplitude of 1 and have a baseline of 0. The current-referenced PSD should be a single array that contains the two-sided in units of <img src="https://render.githubusercontent.com/render/math?math=%5Cmathrm%7BA%7D%5E2%20%2F%20%5Cmathrm%7BHz%7D">. Note that both of these will should have the same digitization rate and length as the data that will be processed to be able to calculate the optimum filter features.
+
+We have also specified to extract 3 different features from each event: `of_nodelay`, `baseline`, and `integral`. This is done by specifying `run: True` in the file, as compared to `run: False` for `of_unconstrained` and `of_constrained`. Note that it is fine to simple exclude features from the YAML file, as they simply will not be calculated (e.g. `energyabsorbed` is not included in this example).
+
+For the features themselves, the functions to extract them may require extra arguments. In this example, `baseline` requires the user to pass the `end_index` value, and `integral` requires the user to pass both `start_index` and `end_index`. There are no default values for these features, so these arguments must be passed. To know what is needed for each feature, the docstrings of these features can be accessed through `detprocess.SingleChannelExtractors`.
+
+### Extracting Features
+
+Feature extraction is meant to be very easy once we have our features and our YAML file. Essentially all of the work is done by `detprocess.process_data`. This function takes the absolute path to the file to be processed and the absolute path to the YAML file, and then will return a DataFrame containing all of the extracted features.
+
+## Advanced Usage
+
+

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To create a new feature, we would follow the format of the above features. Let's
 
 This feature must be added as one of the static methods in the class `SingleChannelExtractors`, located in `detprocess/process/_features.py`. After adding the code, the user must then recompile the package via `pip install .`, and the feature can be extracted by `detprocess`.
 
-If we added this feature to our example [YAML file](#yaml-file), the corresponding entry should be of the form:
+If we added this feature to our example [YAML file](#yaml-file), the corresponding entry should be of the form (where we are currently passing dummy values to the dummy parameters):
 
 ```yaml
     example_feature:

--- a/detprocess/__init__.py
+++ b/detprocess/__init__.py
@@ -1,2 +1,3 @@
 from . import process
+from .process import process_data, SingleChannelExtractors
 from . import io

--- a/detprocess/io/_load.py
+++ b/detprocess/io/_load.py
@@ -26,9 +26,11 @@ def load_traces(filename, channels=None, nevents=0):
     Returns
     -------
     traces : ndarray
-        A numpy array of traces of shape (number of traces, number of channels, length of individual trace.
+        A numpy array of traces of shape (number of traces, number of
+        channels, length of individual trace.
     info_dict : dict
-        A dictionary containing information that comes directly from the loaded file.
+        A dictionary containing information that comes directly from
+        the loaded file.
 
     """
 
@@ -59,9 +61,9 @@ def load_features(file_or_folder):
     Parameters
     ----------
     file_or_folder : str
-        The full path and filename for the detprocess HDF5 file to open, or
-        the full path to the folder containing a number of detprocess HDF5
-        files to open.
+        The full path and filename for the detprocess HDF5 file to
+        open, or the full path to the folder containing a number of
+        detprocess HDF5 files to open.
 
     Returns
     -------
@@ -70,7 +72,6 @@ def load_features(file_or_folder):
         specified file.
 
     """
-
     
     if Path(file_or_folder).is_dir():
         df = pd.concat(

--- a/detprocess/io/_load.py
+++ b/detprocess/io/_load.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+from glob import glob
+from pathlib import Path
 
 import pytesdaq.io.hdf5 as h5io
 
@@ -49,25 +51,41 @@ def load_traces(filename, channels=None, nevents=0):
     return traces, info_dict
 
 
-def load_features(filename):
+def load_features(file_or_folder):
     """
-    Function for loading the features from an HDF5 that was created by detprocess.
+    Function for loading the features from an HDF5 that was created by
+    detprocess.
 
     Parameters
     ----------
-    filename : str
-        The full path and filename for the detprocess HDF5 file to open.
+    file_or_folder : str
+        The full path and filename for the detprocess HDF5 file to open, or
+        the full path to the folder containing a number of detprocess HDF5
+        files to open.
 
     Returns
     -------
     df : Pandas.DataFrame
-        A DataFrame that contains all of the extracted features for the specified file.
-    
+        A DataFrame that contains all of the extracted features for the
+        specified file.
+
     """
-    df = pd.read_hdf(
-        filename,
-        'detprocess_df',
-    )
+
+    
+    if Path(file_or_folder).is_dir():
+        df = pd.concat(
+            [
+                pd.read_hdf(
+                    f,
+                    'detprocess_df',
+                ) for f in sorted(glob(f"{file_or_folder}/*.hdf5"))
+            ],
+        )
+    else:
+        df = pd.read_hdf(
+            file_or_folder,
+            'detprocess_df',
+        )
 
     return df
 

--- a/detprocess/io/_save.py
+++ b/detprocess/io/_save.py
@@ -13,7 +13,8 @@ def save_features(df, filename):
     Parameters
     ----------
     df : Pandas.DataFrame
-        A DataFrame that contains all of the extracted features for a file.
+        A DataFrame that contains all of the extracted features for a
+        file.
     filename : str
         The full path and file name to save the DataFrame as.
 
@@ -22,6 +23,7 @@ def save_features(df, filename):
     None
 
     """
+
     df.to_hdf(
         filename,
         key='detprocess_df',

--- a/detprocess/process/_features.py
+++ b/detprocess/process/_features.py
@@ -12,19 +12,21 @@ __all__ = [
 def repack_h5info_dict(h5info_dict):
     """
 
-    Helper function to repackage the hdf5 file event info (metadata)  dictionaries into a dictionary
-    with a format that can be used in the rq dataframe
+    Helper function to repackage the hdf5 file event info (metadata)
+    dictionaries into a dictionary with a format that can be used in
+    the rq dataframe
 
     Parameters
     ----------
     h5dict : list
-        A list of dictionaries (one dictionary per event) with format as output by the pytesdaq
-        function read_many_events
+        A list of dictionaries (one dictionary per event) with format
+        as output by the pytesdaq function read_many_events
 
     Returns
     -------
     retdict : dict
-        A dictionary of numpy arrays containing event metadata (eventnumber, seriesnumber, etc.)
+        A dictionary of numpy arrays containing event metadata
+        (eventnumber, seriesnumber, etc.)
 
     """
 
@@ -91,7 +93,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         template : ndarray
             The template to use for the optimum filter.
         psd : ndarray
@@ -130,7 +133,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         template : ndarray
             The template to use for the optimum filter.
         psd : ndarray
@@ -170,7 +174,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         template : ndarray
             The template to use for the optimum filter.
         psd : ndarray
@@ -217,7 +222,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         end_index : int
             The index of the trace to average the trace up to.
 
@@ -246,7 +252,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         start_index : int
             The index of the trace to start the integration.
         end_index : int
@@ -278,7 +285,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         start_index : int
             The index of the trace to start searching for the max.
         end_index : int
@@ -308,7 +316,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         start_index : int
             The index of the trace to start searching for the min.
         end_index : int
@@ -338,7 +347,8 @@ class SingleChannelExtractors(object):
         Parameters
         ----------
         trace : ndarray
-            An ndarray containing the raw data to extract the feature from.
+            An ndarray containing the raw data to extract the feature
+            from.
         start_index : int
             The index of the trace to start the integration.
         end_index : int

--- a/detprocess/process/_features.py
+++ b/detprocess/process/_features.py
@@ -118,6 +118,7 @@ class SingleChannelExtractors(object):
             'ofamp_nodelay': ofamp_nodelay,
             'ofchi2_nodelay': ofchi2_nodelay,
         }
+
         return retdict
 
 
@@ -217,7 +218,7 @@ class SingleChannelExtractors(object):
         ----------
         trace : ndarray
             An ndarray containing the raw data to extract the feature from.
-        end_index : ndarray
+        end_index : int
             The index of the trace to average the trace up to.
 
         Returns
@@ -246,9 +247,9 @@ class SingleChannelExtractors(object):
         ----------
         trace : ndarray
             An ndarray containing the raw data to extract the feature from.
-        start_index : ndarray
+        start_index : int
             The index of the trace to start the integration.
-        end_index : ndarray
+        end_index : int
             The index of the trace to end the integration.
         fs : float
             The digitization rate of the data in trace.
@@ -278,9 +279,9 @@ class SingleChannelExtractors(object):
         ----------
         trace : ndarray
             An ndarray containing the raw data to extract the feature from.
-        start_index : ndarray
+        start_index : int
             The index of the trace to start searching for the max.
-        end_index : ndarray
+        end_index : int
             The index of the trace to end searching for the max.
 
         Returns
@@ -308,9 +309,9 @@ class SingleChannelExtractors(object):
         ----------
         trace : ndarray
             An ndarray containing the raw data to extract the feature from.
-        start_index : ndarray
+        start_index : int
             The index of the trace to start searching for the min.
-        end_index : ndarray
+        end_index : int
             The index of the trace to end searching for the min.
 
         Returns
@@ -338,9 +339,9 @@ class SingleChannelExtractors(object):
         ----------
         trace : ndarray
             An ndarray containing the raw data to extract the feature from.
-        start_index : ndarray
+        start_index : int
             The index of the trace to start the integration.
-        end_index : ndarray
+        end_index : int
             The index of the trace to end the integration.
         fs : float
             The digitization rate of the data in trace.

--- a/detprocess/process/_process.py
+++ b/detprocess/process/_process.py
@@ -16,27 +16,35 @@ __all__ = [
 
 def _get_single_channel_feature_names(chan_dict):
     """Helper function for getting feature extractors."""
+
     feature_list = []
     for feature in chan_dict:
         if isinstance(chan_dict[feature], dict) and chan_dict[feature]['run']:
             feature_list.append(feature)
+
     return feature_list
 
 
-def process_data(raw_file, path_to_yaml, nevents=0, savepath=None):
+def process_data(raw_file, path_to_yaml, savepath, nevents=0):
     """
-    Function for extracting features from a data file using the settings from a specified YAML file.
+    Function for extracting features from a data file using the
+    settings from a specified YAML file.
 
     Parameters
     ----------
     raw_file : str
-        Full path and file name to the HDF5 file to be processed. Assumed to have been created by `pytesdaq`.
+        Full path and file name to the HDF5 file to be processed.
+        Assumed to have been created by `pytesdaq`.
     path_to_yaml : str
-        Full path and file name to the YAML settings for the processing.
-    nevents : int
-        The number of events to process in the file. Default of 0 is to process all events. Generally used for development purposes.
+        Full path and file name to the YAML settings for the
+        processing.
     savepath : str, NoneType
-        The path to the folder to save the extracted features to (as an HDF5 file). If left as None, then the data will not be saved anywhere, and a warning will be shown specifying this.
+        The path to the folder to save the extracted features to (as an
+        HDF5 file). If set to None, then the data will not be saved
+        anywhere, and a warning will be shown specifying this.
+    nevents : int, optional
+        The number of events to process in the file. Default of 0 is to
+        process all events. Generally used for development purposes.
 
     Returns
     -------
@@ -46,7 +54,10 @@ def process_data(raw_file, path_to_yaml, nevents=0, savepath=None):
     """
 
     if savepath is None:
-        warnings.warn('savepath has not been set, the extracted features will be returned, but not saved to a file.')
+        warnings.warn(
+            'savepath has been set to None, the extracted features '
+            'will be returned, but not saved to a file.'
+        )
 
     with open(path_to_yaml) as f:
         yaml_dict = yaml.safe_load(f)

--- a/examples/run_detprocess.ipynb
+++ b/examples/run_detprocess.ipynb
@@ -56,8 +56,8 @@
     "    df_temp = detp.process_data(\n",
     "        file,\n",
     "        yaml_path,\n",
-    "#         nevents=10, # for debugging\n",
-    "        savepath=save_path,\n",
+    "        save_path, # pass None if you don't want to save the file (for debugging)\n",
+    "#         nevents=10, # process only the first 10 events (for debugging)\n",
     "    )"
    ]
   },
@@ -87,7 +87,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -101,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/examples/run_detprocess.ipynb
+++ b/examples/run_detprocess.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using `detprocess`\n",
+    "\n",
+    "This example notebook shows the expected usage for `detprocess.process_data`.\n",
+    "\n",
+    "We start by importing `detprocess`, and we will use `glob` for convenience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import detprocess as detp\n",
+    "from glob import glob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then need to specify three paths: the full path to the YAML file containing the processing settings, the full path to the folder that containis the data saved by `pytesdaq` that will be loaded and processed, and the full path to the folder that the processed files should be saved to (make sure it exists!)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yaml_path = '/path/to/yaml_file.yaml'\n",
+    "trigger_path = '/path/to/pytesdaq_data_folder/'\n",
+    "save_path = '/path/to/save/processed_data/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To process the data, we use the function `detprocess.process_data`. This function only supports reading a single file at a time, so we must loop through all of the `pytesdaq` files, saving each individual processed file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for file in sorted(glob(f\"{trigger_path}/*.hdf5\")):\n",
+    "    df_temp = detp.process_data(\n",
+    "        file,\n",
+    "        yaml_path,\n",
+    "#         nevents=10, # for debugging\n",
+    "        savepath=save_path,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After all files have been processed, then the user can load the data from anywhere with just the path to the folder that contains the processed data, as shown below with the function `detprocess.io.load_features`. With the data loaded, the user can then use these features for their analysis!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = detp.io.load_features(save_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR is mostly based on improving the package's documentation, but there are a couple of user-friendly changes.

- In-depth README has been written
- Example notebook on processing data has been added
- `process_data` and `SingleChannelExtractors` can be called from `detprocess` instead of `detprocess.process`
- `detprocess.io.load_features` supports passing a path to a directory containing many `detprocess` HDF5 files
- `savepath` in `detprocess.process_data` is now a required argument
- Updated white space in the code such that docstring lines are not too long